### PR TITLE
🪲 fixed #23 (project페이지) 모바일 스크린일 때, 레이아웃 버그 이슈 수정  

### DIFF
--- a/components/Projects/index.tsx
+++ b/components/Projects/index.tsx
@@ -72,7 +72,7 @@ const Projects = () => {
   return (
     // <Container maxWidth="lg" className="px-0.5 py-3.5">
     //   </Container>
-    <div className="relative mx-auto max-w-2xl py-8 px-4 mobile:py-20 mobile:px-6 laptop:max-w-7xl laptop:px-8">
+    <div className="relative mx-auto max-w-2xl py-8 px-4 mobile:py-4 mobile:px-2 laptop:max-w-7xl laptop:px-8">
       <div
         id="section05"
         className="grid gap-y-10 gap-x-6 mobile:grid-cols-1 tablet:grid-cols-2 laptop:grid-cols-3 desktop:grid-cols-3 desktop:gap-x-8"

--- a/components/Projects/index.tsx
+++ b/components/Projects/index.tsx
@@ -75,7 +75,7 @@ const Projects = () => {
     <div className="relative mx-auto max-w-2xl py-8 px-4 mobile:py-20 mobile:px-6 laptop:max-w-7xl laptop:px-8">
       <div
         id="section05"
-        className="grid grid-cols-1 gap-y-10 gap-x-6 mobile:grid-cols-2 laptop:grid-cols-3 desktop:grid-cols-3 desktop:gap-x-8"
+        className="grid gap-y-10 gap-x-6 mobile:grid-cols-1 tablet:grid-cols-2 laptop:grid-cols-3 desktop:grid-cols-3 desktop:gap-x-8"
       >
         {/* {entries.map((entry: entryType, index: number) => ProjectItem(entry, index))} */}
         {entries.map((entry: entryType, index: number) => ProjectItem(entry, index))}


### PR DESCRIPTION
# PR 사항 
## 이슈
### 1. 모바일 스크린일 때, Projects 페이지의 컨텐츠 grid layout 이 적절하지 않은 버그 이슈 해결
참조 이슈 : #23

### 2. 모바일 스크린일 때, Porjects 페이지의 컨텐츠 컨테이너 `padding-x` 스타일 속성 수정  